### PR TITLE
[host-runner]: Fix duplicate FPGA names

### DIFF
--- a/ci-tools/host-runner/hostrunners/kir-2.nix
+++ b/ci-tools/host-runner/hostrunners/kir-2.nix
@@ -39,11 +39,11 @@ in
       ftdi = "1-1.2.1.4";
       sdwire = "1-1.2.1.3";
     })
-    (fpga_service.mkVckSubsystemJob "caliptra-kir-vck-7" {
+    (fpga_service.mkVckSubsystemJob "caliptra-kir-vck-8" {
       ftdi = "1-1.1.1.2";
       sdwire = "1-1.1.1.4";
     })
-    (fpga_service.mkVckSubsystemJob "caliptra-kir-vck-8" {
+    (fpga_service.mkVckSubsystemJob "caliptra-kir-vck-9" {
       ftdi = "1-1.1.1.1";
       sdwire = "1-1.1.1.3";
     })


### PR DESCRIPTION
Missed that kir-1 already had a VCK-7.