### PR TITLE
fix: update ci-tools workspace members

### DIFF
--- a/ci-tools/Cargo.toml
+++ b/ci-tools/Cargo.toml
@@ -5,6 +5,10 @@ resolver = "2"
 
 members = [
   "size-history",
+  "bitstream-downloader",
+  "fpga-boss",
+  "test-matrix",
+  "test-printer",
 ]
 
 [workspace.dependencies]
@@ -12,4 +16,3 @@ serde = "1"
 serde_json = "1"
 tinytemplate = "1.1"
 openssl = { version = "0.10", features = ["vendored"] }
-


### PR DESCRIPTION
Resolves #50 by adding the ci-tool crates as members of the workspace. Verify locally by running

EDIT:
```
cargo install --git https://github.com/leongross/caliptra-infra --branch fix/ci-tools-workspace caliptra-bitstream-downloader --root /tmp/bitstream-downloader
```