### PR TITLE
[bitstream-downloader]: Make caliptra-ss commit optional

### DIFF
--- a/ci-tools/bitstream-downloader/src/lib.rs
+++ b/ci-tools/bitstream-downloader/src/lib.rs
@@ -26,7 +26,8 @@ pub struct Manifest {
     pub caliptra_variant: String,
     pub date: String,
     pub commit_hash: String,
-    pub caliptra_ss_commit: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub caliptra_ss_commit: Option<String>,
     pub job_id: String,
     pub segmented: bool,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/ci-tools/bitstream-downloader/src/main.rs
+++ b/ci-tools/bitstream-downloader/src/main.rs
@@ -55,7 +55,7 @@ struct BundleManifestArgs {
 
     /// Caliptra SS commit hash
     #[arg(long)]
-    caliptra_ss_commit: String,
+    caliptra_ss_commit: Option<String>,
 
     /// GitHub Actions job ID
     #[arg(long)]


### PR DESCRIPTION
This is to start automating core bitstream builds.