### PR TITLE
add new param 'json_path' for verification of test list

### DIFF
--- a/ci-tools/Cargo.lock
+++ b/ci-tools/Cargo.lock
@@ -2781,6 +2781,7 @@ dependencies = [
  "clap 4.6.1",
  "quick-xml",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/ci-tools/test-printer/Cargo.toml
+++ b/ci-tools/test-printer/Cargo.toml
@@ -8,4 +8,5 @@ edition = "2021"
 [dependencies]
 quick-xml = { version = "0.31.0", features = ["serialize"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 clap = { version = "4.4.18", features = ["derive"] }

--- a/ci-tools/test-printer/src/main.rs
+++ b/ci-tools/test-printer/src/main.rs
@@ -3,6 +3,8 @@
 use clap::Parser;
 use serde::Deserialize;
 use std::fs;
+use serde_json::Value;
+use std::collections::HashSet;
 
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
@@ -10,6 +12,9 @@ struct Args {
     /// The path to the junit.xml file
     #[clap(short, long)]
     xml_path: String,
+    /// The path to the list.json file
+    #[clap(short, long)]
+    json_path: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -59,10 +64,41 @@ struct TestResult {
     time: f64,
 }
 
-fn main() {
+fn parse_list_json(json_path: String) -> HashSet<String> {
+    let list_json = fs::read_to_string(json_path).expect("Unable to read list.json");
+    let test_list: Value = serde_json::from_str(&list_json).expect("Unable to parse JSON");
+    let mut list_set: HashSet<String> = HashSet::new();
+
+    if let Some(suites) = test_list["rust-suites"].as_object() {
+        for suite in suites.keys() {
+            if let Some(testcases) = test_list["rust-suites"][suite]["testcases"].as_object() {
+                for case in testcases.keys() {
+                    list_set.insert(format!("{}::{}", suite, case));
+                }
+            }
+        }
+    }
+
+    list_set
+}
+
+fn validate_result_list(list_set: &HashSet<String>, run_set: &HashSet<String>) -> Result<(), String> {
+    let mut diff: Vec<&String> = list_set.difference(&run_set).collect();
+    diff.sort_unstable();
+    if diff.len() > 0 {
+        println!("Tests not executed: {:#?}", diff);
+        return Err(format!("tests not executed = {}", diff.len()));
+    }
+    Ok(())
+}
+
+fn main() -> Result<(), String> {
     let args = Args::parse();
-    let xml = fs::read_to_string(args.xml_path).expect("Unable to read junit.xml");
-    let testsuites: TestSuites = quick_xml::de::from_str(&xml).expect("Unable to parse XML");
+
+    let junit_xml = fs::read_to_string(args.xml_path).expect("Unable to read junit.xml");
+    let testsuites: TestSuites = quick_xml::de::from_str(&junit_xml).expect("Unable to parse XML");
+
+    let mut run_set: HashSet<String> = HashSet::new();
 
     let mut results = Vec::new();
 
@@ -81,6 +117,8 @@ fn main() {
                 TestStatus::Failed => "❌",
                 TestStatus::Retried => "🔁",
             };
+            
+            run_set.insert(format!("{}::{}", suite.name, case.name));
 
             results.push(TestResult {
                 suite_name: suite.name.clone(),
@@ -91,6 +129,19 @@ fn main() {
             });
         }
     }
+
+    if args.json_path.is_some() {
+        let list_set: HashSet<String> = parse_list_json(args.json_path.expect("Missing json_path argument"));
+        match validate_result_list(&list_set, &run_set) {
+            Ok(()) => (),
+            Err(e) => {
+                eprintln!("Error validating list: {e:#}");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    // no validation list, or list matches : in either case, now print the results
 
     // Sort by status priority (failures first, then flaky, then slow, then the rest)
     results.sort_by(|a, b| {
@@ -112,4 +163,6 @@ fn main() {
             result.suite_name, result.case_name, result.status_icon, result.time
         );
     }
+
+    Ok(())
 }


### PR DESCRIPTION
[test-printer] Added new optional parameter "json-path".
When provided, will compare expected list of tests ("list.json") with executed result (junit.xml).
Throws error if list of tests "not run / without result" is not empty.